### PR TITLE
Devel

### DIFF
--- a/io/ekt8/blockchain/block.go
+++ b/io/ekt8/blockchain/block.go
@@ -117,8 +117,6 @@ func (block *Block) newAccount(address []byte, pubKey []byte) {
 }
 
 func (block *Block) NewTransaction(tx *common.Transaction, fee int64) *common.TxResult {
-	block.Locker.Lock()
-	defer block.Locker.Unlock()
 	fromAddress, _ := hex.DecodeString(tx.From)
 	toAddress, _ := hex.DecodeString(tx.To)
 	account, _ := block.GetAccount(fromAddress)

--- a/io/ekt8/core/common/account.go
+++ b/io/ekt8/core/common/account.go
@@ -5,9 +5,14 @@ import (
 	"fmt"
 )
 
+const (
+	Default_Crypto_Method = "secp256k1"
+)
+
 type Account struct {
 	hexAddress    string           `json:"address"`
 	hexPublickKey string           `json:"publicKey"`
+	cryptoMethod  string           `json:"cryptoMethod"`
 	amount        int64            `json:"amount"`
 	nonce         int64            `json:"nonce"`
 	balances      map[string]int64 `json:"balances"`

--- a/io/ekt8/core/common/transaction.go
+++ b/io/ekt8/core/common/transaction.go
@@ -17,6 +17,7 @@ type Transaction struct {
 	TimeStamp    Time   `json:"time"` // UnixTimeStamp
 	Amount       int64  `json:"amount"`
 	Nonce        int64  `json:"nonce"`
+	Data         string `json:"data"`
 	TokenAddress string `json:"tokenAddress"`
 	Sign         string `json:"sign"`
 }

--- a/io/ekt8/main.go
+++ b/io/ekt8/main.go
@@ -26,7 +26,7 @@ func init() {
 }
 
 func main() {
-	fmt.Printf("server listen on :%d", conf.EKTConfig.Node.Port)
+	fmt.Printf("server listen on :%d \n", conf.EKTConfig.Node.Port)
 	err := http.ListenAndServe(fmt.Sprintf(":%d", conf.EKTConfig.Node.Port), nil)
 	if err != nil {
 		fmt.Println(err.Error())

--- a/io/ekt8/pool/pool.go
+++ b/io/ekt8/pool/pool.go
@@ -170,7 +170,7 @@ func (pool Pool) FetchEvent() *event.Event {
 func (pool Pool) FetchTx() *common.Transaction {
 	if len(pool.txReady) > 0 {
 		for _, tx := range pool.txReady {
-			delete(pool.txReady, tx.TransactionId())
+			//delete(pool.txReady, tx.TransactionId())
 			return tx
 		}
 	}


### PR DESCRIPTION
打包交易的时候不从pool中删除，而是在收到投票结果写入链中的时候才从pool中删除
打包交易不需要对block加锁，在默克尔证明代码内有自己的lock
在account中增加crypto method，默认pubKey和cryptoMethod为空
在Transaction中增加data，用于开发者开发特殊功能
因为要进行以太坊ERC20的映射和冷钱包，因此一期不支持地址的申请和加密算法的替换，只能打包转账交易 和 token发行 